### PR TITLE
fix: closes #19

### DIFF
--- a/lua/dimmer/config.lua
+++ b/lua/dimmer/config.lua
@@ -1,9 +1,7 @@
 local utils = require("dimmer.utils")
 
-_DimmerConfigurationValues = _DimmerConfigurationValues or {}
-
 local config = {}
-config.values = _DimmerConfigurationValues
+config.values = {}
 
 local defaults = {
   -- TODO: probably want to add nvim-tree, nerdtree, chadtree..

--- a/lua/dimmer/events.lua
+++ b/lua/dimmer/events.lua
@@ -15,12 +15,11 @@ end
 
 local function redraw(_, win_id, _, _, _)
   local overlay = state.overlays[win_id]
-  if not overlay then
+  if not overlay or not state.active then
     return
   end
   ui.win_resize(win_id)
 end
-
 
 function M.init_events()
   init_augroup()


### PR DESCRIPTION
reworked call to `create_overlay` to 1. avoid over-creating overlays 2. under-creating overlays causing issues with windows failing to undim